### PR TITLE
Ignore all node module packages. and escape flow analysis on imported …

### DIFF
--- a/template/.flowconfig
+++ b/template/.flowconfig
@@ -1,11 +1,7 @@
 [ignore]
-.*/node_modules/config-chain/test/broken.json
-.*/node_modules/vue/.*
-.*/node_modules/vue-router/.*
-*.vue
+.*/node_modules/**/.*
 
 [include]
-./src/.*
 
 [libs]
 

--- a/template/src/store/actions.js
+++ b/template/src/store/actions.js
@@ -1,3 +1,5 @@
+// @flow
+// $FlowFixMe
 import { get } from '@molgenis/molgenis-api-client'
 
 export const GET_ENTITY_TYPES = '__GET_ENTITY_TYPES__'
@@ -6,7 +8,7 @@ export default {
   /**
    * Example action for retrieving all EntityTypes from the server
    */
-  [GET_ENTITY_TYPES] ({commit}) {
+  [GET_ENTITY_TYPES] ({commit}: { commit: Function }) {
     /**
      * Pass options to the fetch like body, method, x-molgenis-token etc...
      * @type {{}}


### PR DESCRIPTION
Ignore all node module packages and escape flow analysis on imported packages from node modules.

At the moment flow offers no way exclude all files in node_modules except some named package. As a work around for this missing feature i suggest we ignore everything in the node_modules folder and escape imports from the node_modules folder using '$FlowFixMe' 

for example: 

```
// $FlowFixMe
import { get } from '@molgenis/molgenis-api-client'
```

where @molgenis/molgenis-api-client is a module located in the node_modules folder.